### PR TITLE
Add support for Gatsby 4.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,13 +7,19 @@ const { eslintConfig } = require("gatsby/dist/utils/eslint-config")
 const {
   rules: customGatsbyRules,
 } = require("gatsby/dist/utils/eslint/required")
-const { reactHasJsxRuntime } = require("gatsby/dist/utils/webpack-utils")
+const webpackUtils = require("gatsby/dist/utils/webpack-utils")
 
 // Load GraphQL schema
-const { schema } = store.getState()
+const { schema, program } = store.getState()
+
+// Check if using automatic jsx runtime
+const usingAutomaticJsxRuntime =
+  typeof webpackUtils.createWebpackConfig === "function"
+    ? webpackUtils.createWebpackConfig("develop", program) // Gatsby v4.1+
+    : webpackUtils.hasJsxRuntime()
 
 // Load default configuration
-const config = eslintConfig(schema, reactHasJsxRuntime()).baseConfig
+const config = eslintConfig(schema, usingAutomaticJsxRuntime).baseConfig
 
 module.exports = {
   configs: {


### PR DESCRIPTION
It looks like things moved around quite a bit for Gatsby v4.1 to support the `jsxRuntime` options.

Documented here: https://www.gatsbyjs.com/docs/reference/config-files/gatsby-config/#jsxruntime

PR here: https://github.com/gatsbyjs/gatsby/pull/33050/files

Trying to make this change backwards compatible, and the best place I could see to introspect the option now is off the webpack config's js loader options but perhaps there is a better alternative?